### PR TITLE
NoTask - Port is configurable through process.env.PORT

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -1,7 +1,7 @@
 'use strict';
 let path = require('path');
 
-let port = 8000;
+let port = process.env.PORT || 8000;
 let srcPath = path.join(__dirname, '/../src');
 let publicPath = '/assets/';
 


### PR DESCRIPTION
Thought it would be nice to specify the port when starting the process. In this way, you could run several and set a load balancer without having to change the code.
Example of use:

```
PORT=3333 node server.js
```

Let me know what you think :)
